### PR TITLE
Add Cmake switch for hot code reloading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,11 +67,20 @@ target_include_directories(fft_tryout
 target_include_directories(plug
  PRIVATE
   ${raylib_INCLUDE_DIRS}
-  )
+)
+
+# here is HOTRELAOD checked
+if(DEFINED HOTRELOAD)
+  message("HOTRELOADE enabled (${HOTRELOAD})")
+else(DEFINED HOTRELOAD)
+  set(MUSIC_VISUALIZER_LINK_PLUG_LIB "plug")
+  message("lib plug: ${MUSIC_VISUALIZER_LINK_PLUG_LIB}")
+endif(DEFINED HOTRELOAD)
+# supress cmake warning var is not in use (boilerplate)
 
 target_link_libraries(music_visualizer
   ${raylib_LIBRARIES}
-  #plug
+  ${MUSIC_VISUALIZER_LINK_PLUG_LIB}
 )
 
 target_link_libraries(music_wave_plotter

--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@ Change library search path for cmake
 
 export LD_LIBRARY_PATH="./"
 
+# build
+- run:
+  - `mkdir build`
+  - `cd build`
+  - for hot code reloading:
+  - `cmake -DHOTRELOAD=true ..`
+  - without hot code relaoding: `cmake -DHOTRELOAD=true ..`
+  - `make`


### PR DESCRIPTION
To have a build switch between HOTRELOAD mode and normal build,
a CMake var is added.
This can be used as described in the README.md
- `cmake -DHOTRELOAD=true ..` 
further changes are needed like X Macro defined parts in `plug.h`