### PR TITLE
Fix HOTRELOAD issues with missing macro code gen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ target_include_directories(plug
 # here is HOTRELAOD checked
 if(DEFINED HOTRELOAD)
   message("HOTRELOADE enabled (${HOTRELOAD})")
+  target_compile_definitions(music_visualizer PRIVATE HOTRELOAD)
 else(DEFINED HOTRELOAD)
   set(MUSIC_VISUALIZER_LINK_PLUG_LIB "plug")
   message("lib plug: ${MUSIC_VISUALIZER_LINK_PLUG_LIB}")

--- a/src/main.c
+++ b/src/main.c
@@ -28,11 +28,12 @@ void *libplug = NULL;
 //define LIST_OF_PLUGS from plug.h
 //concatenate token passed to name also to name_t using name##_t
 #define PLUG(name) name##_t *name = NULL;
+LIST_OF_PLUGS
 #else
 #define PLUG(name) name##_t name;
 LIST_OF_PLUGS
-#undef PLUG
 #endif
+#undef PLUG
 
 Plug plug = {0};
 


### PR DESCRIPTION
Fix in main the macro generated 
variables for `plug_init`, `plug_update`...
and pass `HOTRELOAD` define in CMakeLists
to `music_visualizer` target